### PR TITLE
fix: readability of menu item when hovered

### DIFF
--- a/templates/svg.tera
+++ b/templates/svg.tera
@@ -206,20 +206,20 @@ whiskers:
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#{{ accent.hex }}" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#{{ accent.hex }}" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#{{ accent.hex }}" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#{{ accent.hex }}" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#{{ accent.hex }}" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#{{ accent.hex }}" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#{{ accent.hex }}" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#{{ accent.hex }}" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#{{ accent.hex }}" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#{{ accent.hex }}" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#{{ accent.hex }}" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#{{ accent.hex }}" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#{{ accent.hex }}" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#{{ accent.hex }}" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#{{ accent.hex }}" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#{{ accent.hex }}" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#{{ accent.hex }}" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#{{ accent.hex }}" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#{{ mantle.hex }}" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-frappe-blue/catppuccin-frappe-blue.svg
+++ b/themes/catppuccin-frappe-blue/catppuccin-frappe-blue.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#8CAAEE" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#8CAAEE" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#8CAAEE" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#8CAAEE" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#8CAAEE" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#8CAAEE" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#8CAAEE" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#8CAAEE" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#8CAAEE" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#8CAAEE" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#8CAAEE" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#8CAAEE" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#8CAAEE" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#8CAAEE" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#8CAAEE" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#8CAAEE" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#8CAAEE" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#8CAAEE" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#292C3C" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-frappe-flamingo/catppuccin-frappe-flamingo.svg
+++ b/themes/catppuccin-frappe-flamingo/catppuccin-frappe-flamingo.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#EEBEBE" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#EEBEBE" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#EEBEBE" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#EEBEBE" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#EEBEBE" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#EEBEBE" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#EEBEBE" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#EEBEBE" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#EEBEBE" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#EEBEBE" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#EEBEBE" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#EEBEBE" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#EEBEBE" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#EEBEBE" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#EEBEBE" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#EEBEBE" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#EEBEBE" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#EEBEBE" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#292C3C" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-frappe-green/catppuccin-frappe-green.svg
+++ b/themes/catppuccin-frappe-green/catppuccin-frappe-green.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#A6D189" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#A6D189" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#A6D189" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#A6D189" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#A6D189" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#A6D189" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#A6D189" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#A6D189" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#A6D189" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#A6D189" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#A6D189" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#A6D189" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#A6D189" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#A6D189" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#A6D189" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#A6D189" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#A6D189" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#A6D189" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#292C3C" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-frappe-lavender/catppuccin-frappe-lavender.svg
+++ b/themes/catppuccin-frappe-lavender/catppuccin-frappe-lavender.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#BABBF1" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#BABBF1" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#BABBF1" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#BABBF1" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#BABBF1" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#BABBF1" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#BABBF1" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#BABBF1" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#BABBF1" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#BABBF1" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#BABBF1" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#BABBF1" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#BABBF1" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#BABBF1" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#BABBF1" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#BABBF1" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#BABBF1" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#BABBF1" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#292C3C" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-frappe-maroon/catppuccin-frappe-maroon.svg
+++ b/themes/catppuccin-frappe-maroon/catppuccin-frappe-maroon.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#EA999C" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#EA999C" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#EA999C" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#EA999C" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#EA999C" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#EA999C" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#EA999C" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#EA999C" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#EA999C" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#EA999C" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#EA999C" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#EA999C" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#EA999C" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#EA999C" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#EA999C" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#EA999C" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#EA999C" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#EA999C" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#292C3C" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-frappe-mauve/catppuccin-frappe-mauve.svg
+++ b/themes/catppuccin-frappe-mauve/catppuccin-frappe-mauve.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#CA9EE6" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#CA9EE6" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#CA9EE6" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#CA9EE6" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#CA9EE6" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#CA9EE6" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#CA9EE6" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#CA9EE6" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#CA9EE6" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#CA9EE6" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#CA9EE6" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#CA9EE6" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#CA9EE6" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#CA9EE6" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#CA9EE6" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#CA9EE6" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#CA9EE6" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#CA9EE6" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#292C3C" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-frappe-peach/catppuccin-frappe-peach.svg
+++ b/themes/catppuccin-frappe-peach/catppuccin-frappe-peach.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#EF9F76" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#EF9F76" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#EF9F76" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#EF9F76" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#EF9F76" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#EF9F76" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#EF9F76" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#EF9F76" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#EF9F76" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#EF9F76" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#EF9F76" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#EF9F76" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#EF9F76" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#EF9F76" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#EF9F76" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#EF9F76" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#EF9F76" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#EF9F76" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#292C3C" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-frappe-pink/catppuccin-frappe-pink.svg
+++ b/themes/catppuccin-frappe-pink/catppuccin-frappe-pink.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#F4B8E4" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#F4B8E4" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#F4B8E4" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#F4B8E4" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#F4B8E4" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#F4B8E4" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#F4B8E4" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#F4B8E4" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#F4B8E4" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#F4B8E4" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#F4B8E4" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#F4B8E4" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#F4B8E4" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#F4B8E4" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#F4B8E4" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#F4B8E4" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#F4B8E4" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#F4B8E4" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#292C3C" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-frappe-red/catppuccin-frappe-red.svg
+++ b/themes/catppuccin-frappe-red/catppuccin-frappe-red.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#E78284" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#E78284" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#E78284" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#E78284" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#E78284" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#E78284" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#E78284" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#E78284" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#E78284" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#E78284" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#E78284" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#E78284" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#E78284" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#E78284" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#E78284" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#E78284" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#E78284" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#E78284" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#292C3C" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-frappe-rosewater/catppuccin-frappe-rosewater.svg
+++ b/themes/catppuccin-frappe-rosewater/catppuccin-frappe-rosewater.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#F2D5CF" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#F2D5CF" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#F2D5CF" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#F2D5CF" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#F2D5CF" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#F2D5CF" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#F2D5CF" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#F2D5CF" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#F2D5CF" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#F2D5CF" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#F2D5CF" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#F2D5CF" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#F2D5CF" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#F2D5CF" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#F2D5CF" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#F2D5CF" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#F2D5CF" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#F2D5CF" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#292C3C" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-frappe-sapphire/catppuccin-frappe-sapphire.svg
+++ b/themes/catppuccin-frappe-sapphire/catppuccin-frappe-sapphire.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#85C1DC" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#85C1DC" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#85C1DC" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#85C1DC" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#85C1DC" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#85C1DC" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#85C1DC" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#85C1DC" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#85C1DC" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#85C1DC" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#85C1DC" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#85C1DC" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#85C1DC" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#85C1DC" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#85C1DC" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#85C1DC" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#85C1DC" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#85C1DC" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#292C3C" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-frappe-sky/catppuccin-frappe-sky.svg
+++ b/themes/catppuccin-frappe-sky/catppuccin-frappe-sky.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#99D1DB" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#99D1DB" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#99D1DB" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#99D1DB" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#99D1DB" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#99D1DB" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#99D1DB" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#99D1DB" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#99D1DB" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#99D1DB" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#99D1DB" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#99D1DB" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#99D1DB" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#99D1DB" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#99D1DB" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#99D1DB" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#99D1DB" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#99D1DB" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#292C3C" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-frappe-teal/catppuccin-frappe-teal.svg
+++ b/themes/catppuccin-frappe-teal/catppuccin-frappe-teal.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#81C8BE" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#81C8BE" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#81C8BE" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#81C8BE" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#81C8BE" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#81C8BE" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#81C8BE" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#81C8BE" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#81C8BE" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#81C8BE" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#81C8BE" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#81C8BE" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#81C8BE" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#81C8BE" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#81C8BE" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#81C8BE" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#81C8BE" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#81C8BE" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#292C3C" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-frappe-yellow/catppuccin-frappe-yellow.svg
+++ b/themes/catppuccin-frappe-yellow/catppuccin-frappe-yellow.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#E5C890" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#E5C890" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#E5C890" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#E5C890" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#E5C890" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#E5C890" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#E5C890" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#E5C890" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#E5C890" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#E5C890" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#E5C890" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#E5C890" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#E5C890" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#E5C890" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#E5C890" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#E5C890" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#E5C890" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#E5C890" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#292C3C" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-latte-blue/catppuccin-latte-blue.svg
+++ b/themes/catppuccin-latte-blue/catppuccin-latte-blue.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#1E66F5" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#1E66F5" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#1E66F5" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#1E66F5" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#1E66F5" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#1E66F5" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#1E66F5" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#1E66F5" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#1E66F5" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#1E66F5" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#1E66F5" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#1E66F5" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#1E66F5" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#1E66F5" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#1E66F5" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#1E66F5" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#1E66F5" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#1E66F5" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#E6E9EF" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-latte-flamingo/catppuccin-latte-flamingo.svg
+++ b/themes/catppuccin-latte-flamingo/catppuccin-latte-flamingo.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#DD7878" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#DD7878" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#DD7878" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#DD7878" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#DD7878" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#DD7878" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#DD7878" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#DD7878" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#DD7878" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#DD7878" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#DD7878" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#DD7878" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#DD7878" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#DD7878" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#DD7878" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#DD7878" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#DD7878" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#DD7878" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#E6E9EF" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-latte-green/catppuccin-latte-green.svg
+++ b/themes/catppuccin-latte-green/catppuccin-latte-green.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#40A02B" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#40A02B" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#40A02B" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#40A02B" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#40A02B" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#40A02B" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#40A02B" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#40A02B" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#40A02B" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#40A02B" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#40A02B" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#40A02B" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#40A02B" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#40A02B" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#40A02B" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#40A02B" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#40A02B" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#40A02B" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#E6E9EF" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-latte-lavender/catppuccin-latte-lavender.svg
+++ b/themes/catppuccin-latte-lavender/catppuccin-latte-lavender.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#7287FD" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#7287FD" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#7287FD" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#7287FD" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#7287FD" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#7287FD" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#7287FD" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#7287FD" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#7287FD" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#7287FD" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#7287FD" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#7287FD" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#7287FD" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#7287FD" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#7287FD" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#7287FD" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#7287FD" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#7287FD" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#E6E9EF" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-latte-maroon/catppuccin-latte-maroon.svg
+++ b/themes/catppuccin-latte-maroon/catppuccin-latte-maroon.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#E64553" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#E64553" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#E64553" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#E64553" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#E64553" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#E64553" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#E64553" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#E64553" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#E64553" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#E64553" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#E64553" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#E64553" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#E64553" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#E64553" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#E64553" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#E64553" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#E64553" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#E64553" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#E6E9EF" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-latte-mauve/catppuccin-latte-mauve.svg
+++ b/themes/catppuccin-latte-mauve/catppuccin-latte-mauve.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#8839EF" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#8839EF" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#8839EF" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#8839EF" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#8839EF" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#8839EF" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#8839EF" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#8839EF" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#8839EF" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#8839EF" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#8839EF" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#8839EF" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#8839EF" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#8839EF" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#8839EF" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#8839EF" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#8839EF" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#8839EF" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#E6E9EF" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-latte-peach/catppuccin-latte-peach.svg
+++ b/themes/catppuccin-latte-peach/catppuccin-latte-peach.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#FE640B" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#FE640B" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#FE640B" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#FE640B" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#FE640B" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#FE640B" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#FE640B" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#FE640B" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#FE640B" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#FE640B" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#FE640B" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#FE640B" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#FE640B" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#FE640B" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#FE640B" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#FE640B" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#FE640B" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#FE640B" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#E6E9EF" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-latte-pink/catppuccin-latte-pink.svg
+++ b/themes/catppuccin-latte-pink/catppuccin-latte-pink.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#EA76CB" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#EA76CB" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#EA76CB" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#EA76CB" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#EA76CB" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#EA76CB" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#EA76CB" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#EA76CB" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#EA76CB" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#EA76CB" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#EA76CB" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#EA76CB" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#EA76CB" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#EA76CB" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#EA76CB" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#EA76CB" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#EA76CB" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#EA76CB" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#E6E9EF" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-latte-red/catppuccin-latte-red.svg
+++ b/themes/catppuccin-latte-red/catppuccin-latte-red.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#D20F39" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#D20F39" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#D20F39" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#D20F39" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#D20F39" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#D20F39" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#D20F39" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#D20F39" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#D20F39" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#D20F39" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#D20F39" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#D20F39" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#D20F39" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#D20F39" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#D20F39" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#D20F39" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#D20F39" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#D20F39" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#E6E9EF" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-latte-rosewater/catppuccin-latte-rosewater.svg
+++ b/themes/catppuccin-latte-rosewater/catppuccin-latte-rosewater.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#DC8A78" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#DC8A78" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#DC8A78" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#DC8A78" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#DC8A78" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#DC8A78" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#DC8A78" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#DC8A78" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#DC8A78" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#DC8A78" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#DC8A78" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#DC8A78" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#DC8A78" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#DC8A78" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#DC8A78" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#DC8A78" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#DC8A78" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#DC8A78" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#E6E9EF" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-latte-sapphire/catppuccin-latte-sapphire.svg
+++ b/themes/catppuccin-latte-sapphire/catppuccin-latte-sapphire.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#209FB5" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#209FB5" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#209FB5" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#209FB5" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#209FB5" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#209FB5" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#209FB5" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#209FB5" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#209FB5" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#209FB5" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#209FB5" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#209FB5" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#209FB5" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#209FB5" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#209FB5" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#209FB5" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#209FB5" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#209FB5" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#E6E9EF" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-latte-sky/catppuccin-latte-sky.svg
+++ b/themes/catppuccin-latte-sky/catppuccin-latte-sky.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#04A5E5" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#04A5E5" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#04A5E5" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#04A5E5" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#04A5E5" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#04A5E5" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#04A5E5" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#04A5E5" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#04A5E5" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#04A5E5" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#04A5E5" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#04A5E5" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#04A5E5" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#04A5E5" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#04A5E5" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#04A5E5" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#04A5E5" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#04A5E5" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#E6E9EF" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-latte-teal/catppuccin-latte-teal.svg
+++ b/themes/catppuccin-latte-teal/catppuccin-latte-teal.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#179299" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#179299" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#179299" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#179299" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#179299" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#179299" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#179299" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#179299" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#179299" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#179299" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#179299" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#179299" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#179299" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#179299" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#179299" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#179299" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#179299" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#179299" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#E6E9EF" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-latte-yellow/catppuccin-latte-yellow.svg
+++ b/themes/catppuccin-latte-yellow/catppuccin-latte-yellow.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#DF8E1D" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#DF8E1D" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#DF8E1D" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#DF8E1D" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#DF8E1D" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#DF8E1D" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#DF8E1D" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#DF8E1D" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#DF8E1D" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#DF8E1D" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#DF8E1D" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#DF8E1D" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#DF8E1D" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#DF8E1D" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#DF8E1D" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#DF8E1D" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#DF8E1D" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#DF8E1D" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#E6E9EF" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-macchiato-blue/catppuccin-macchiato-blue.svg
+++ b/themes/catppuccin-macchiato-blue/catppuccin-macchiato-blue.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#8AADF4" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#8AADF4" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#8AADF4" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#8AADF4" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#8AADF4" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#8AADF4" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#8AADF4" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#8AADF4" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#8AADF4" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#8AADF4" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#8AADF4" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#8AADF4" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#8AADF4" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#8AADF4" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#8AADF4" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#8AADF4" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#8AADF4" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#8AADF4" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#1E2030" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-macchiato-flamingo/catppuccin-macchiato-flamingo.svg
+++ b/themes/catppuccin-macchiato-flamingo/catppuccin-macchiato-flamingo.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#F0C6C6" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#F0C6C6" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#F0C6C6" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#F0C6C6" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#F0C6C6" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#F0C6C6" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#F0C6C6" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#F0C6C6" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#F0C6C6" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#F0C6C6" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#F0C6C6" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#F0C6C6" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#F0C6C6" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#F0C6C6" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#F0C6C6" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#F0C6C6" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#F0C6C6" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#F0C6C6" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#1E2030" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-macchiato-green/catppuccin-macchiato-green.svg
+++ b/themes/catppuccin-macchiato-green/catppuccin-macchiato-green.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#A6DA95" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#A6DA95" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#A6DA95" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#A6DA95" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#A6DA95" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#A6DA95" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#A6DA95" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#A6DA95" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#A6DA95" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#A6DA95" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#A6DA95" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#A6DA95" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#A6DA95" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#A6DA95" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#A6DA95" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#A6DA95" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#A6DA95" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#A6DA95" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#1E2030" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-macchiato-lavender/catppuccin-macchiato-lavender.svg
+++ b/themes/catppuccin-macchiato-lavender/catppuccin-macchiato-lavender.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#B7BDF8" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#B7BDF8" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#B7BDF8" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#B7BDF8" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#B7BDF8" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#B7BDF8" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#B7BDF8" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#B7BDF8" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#B7BDF8" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#B7BDF8" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#B7BDF8" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#B7BDF8" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#B7BDF8" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#B7BDF8" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#B7BDF8" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#B7BDF8" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#B7BDF8" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#B7BDF8" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#1E2030" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-macchiato-maroon/catppuccin-macchiato-maroon.svg
+++ b/themes/catppuccin-macchiato-maroon/catppuccin-macchiato-maroon.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#EE99A0" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#EE99A0" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#EE99A0" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#EE99A0" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#EE99A0" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#EE99A0" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#EE99A0" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#EE99A0" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#EE99A0" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#EE99A0" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#EE99A0" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#EE99A0" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#EE99A0" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#EE99A0" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#EE99A0" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#EE99A0" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#EE99A0" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#EE99A0" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#1E2030" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-macchiato-mauve/catppuccin-macchiato-mauve.svg
+++ b/themes/catppuccin-macchiato-mauve/catppuccin-macchiato-mauve.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#C6A0F6" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#C6A0F6" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#C6A0F6" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#C6A0F6" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#C6A0F6" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#C6A0F6" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#C6A0F6" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#C6A0F6" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#C6A0F6" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#C6A0F6" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#C6A0F6" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#C6A0F6" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#C6A0F6" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#C6A0F6" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#C6A0F6" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#C6A0F6" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#C6A0F6" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#C6A0F6" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#1E2030" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-macchiato-peach/catppuccin-macchiato-peach.svg
+++ b/themes/catppuccin-macchiato-peach/catppuccin-macchiato-peach.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#F5A97F" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#F5A97F" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#F5A97F" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#F5A97F" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#F5A97F" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#F5A97F" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#F5A97F" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#F5A97F" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#F5A97F" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#F5A97F" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#F5A97F" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#F5A97F" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#F5A97F" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#F5A97F" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#F5A97F" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#F5A97F" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#F5A97F" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#F5A97F" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#1E2030" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-macchiato-pink/catppuccin-macchiato-pink.svg
+++ b/themes/catppuccin-macchiato-pink/catppuccin-macchiato-pink.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#F5BDE6" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#F5BDE6" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#F5BDE6" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#F5BDE6" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#F5BDE6" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#F5BDE6" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#F5BDE6" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#F5BDE6" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#F5BDE6" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#F5BDE6" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#F5BDE6" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#F5BDE6" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#F5BDE6" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#F5BDE6" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#F5BDE6" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#F5BDE6" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#F5BDE6" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#F5BDE6" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#1E2030" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-macchiato-red/catppuccin-macchiato-red.svg
+++ b/themes/catppuccin-macchiato-red/catppuccin-macchiato-red.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#ED8796" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#ED8796" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#ED8796" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#ED8796" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#ED8796" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#ED8796" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#ED8796" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#ED8796" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#ED8796" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#ED8796" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#ED8796" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#ED8796" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#ED8796" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#ED8796" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#ED8796" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#ED8796" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#ED8796" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#ED8796" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#1E2030" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-macchiato-rosewater/catppuccin-macchiato-rosewater.svg
+++ b/themes/catppuccin-macchiato-rosewater/catppuccin-macchiato-rosewater.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#F4DBD6" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#F4DBD6" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#F4DBD6" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#F4DBD6" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#F4DBD6" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#F4DBD6" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#F4DBD6" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#F4DBD6" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#F4DBD6" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#F4DBD6" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#F4DBD6" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#F4DBD6" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#F4DBD6" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#F4DBD6" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#F4DBD6" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#F4DBD6" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#F4DBD6" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#F4DBD6" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#1E2030" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-macchiato-sapphire/catppuccin-macchiato-sapphire.svg
+++ b/themes/catppuccin-macchiato-sapphire/catppuccin-macchiato-sapphire.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#7DC4E4" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#7DC4E4" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#7DC4E4" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#7DC4E4" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#7DC4E4" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#7DC4E4" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#7DC4E4" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#7DC4E4" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#7DC4E4" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#7DC4E4" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#7DC4E4" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#7DC4E4" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#7DC4E4" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#7DC4E4" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#7DC4E4" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#7DC4E4" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#7DC4E4" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#7DC4E4" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#1E2030" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-macchiato-sky/catppuccin-macchiato-sky.svg
+++ b/themes/catppuccin-macchiato-sky/catppuccin-macchiato-sky.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#91D7E3" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#91D7E3" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#91D7E3" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#91D7E3" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#91D7E3" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#91D7E3" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#91D7E3" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#91D7E3" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#91D7E3" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#91D7E3" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#91D7E3" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#91D7E3" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#91D7E3" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#91D7E3" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#91D7E3" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#91D7E3" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#91D7E3" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#91D7E3" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#1E2030" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-macchiato-teal/catppuccin-macchiato-teal.svg
+++ b/themes/catppuccin-macchiato-teal/catppuccin-macchiato-teal.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#8BD5CA" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#8BD5CA" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#8BD5CA" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#8BD5CA" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#8BD5CA" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#8BD5CA" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#8BD5CA" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#8BD5CA" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#8BD5CA" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#8BD5CA" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#8BD5CA" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#8BD5CA" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#8BD5CA" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#8BD5CA" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#8BD5CA" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#8BD5CA" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#8BD5CA" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#8BD5CA" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#1E2030" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-macchiato-yellow/catppuccin-macchiato-yellow.svg
+++ b/themes/catppuccin-macchiato-yellow/catppuccin-macchiato-yellow.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#EED49F" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#EED49F" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#EED49F" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#EED49F" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#EED49F" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#EED49F" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#EED49F" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#EED49F" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#EED49F" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#EED49F" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#EED49F" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#EED49F" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#EED49F" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#EED49F" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#EED49F" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#EED49F" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#EED49F" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#EED49F" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#1E2030" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-mocha-blue/catppuccin-mocha-blue.svg
+++ b/themes/catppuccin-mocha-blue/catppuccin-mocha-blue.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#89B4FA" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#89B4FA" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#89B4FA" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#89B4FA" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#89B4FA" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#89B4FA" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#89B4FA" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#89B4FA" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#89B4FA" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#89B4FA" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#89B4FA" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#89B4FA" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#89B4FA" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#89B4FA" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#89B4FA" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#89B4FA" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#89B4FA" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#89B4FA" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#181825" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-mocha-flamingo/catppuccin-mocha-flamingo.svg
+++ b/themes/catppuccin-mocha-flamingo/catppuccin-mocha-flamingo.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#F2CDCD" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#F2CDCD" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#F2CDCD" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#F2CDCD" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#F2CDCD" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#F2CDCD" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#F2CDCD" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#F2CDCD" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#F2CDCD" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#F2CDCD" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#F2CDCD" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#F2CDCD" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#F2CDCD" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#F2CDCD" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#F2CDCD" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#F2CDCD" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#F2CDCD" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#F2CDCD" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#181825" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-mocha-green/catppuccin-mocha-green.svg
+++ b/themes/catppuccin-mocha-green/catppuccin-mocha-green.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#A6E3A1" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#A6E3A1" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#A6E3A1" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#A6E3A1" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#A6E3A1" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#A6E3A1" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#A6E3A1" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#A6E3A1" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#A6E3A1" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#A6E3A1" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#A6E3A1" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#A6E3A1" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#A6E3A1" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#A6E3A1" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#A6E3A1" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#A6E3A1" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#A6E3A1" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#A6E3A1" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#181825" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-mocha-lavender/catppuccin-mocha-lavender.svg
+++ b/themes/catppuccin-mocha-lavender/catppuccin-mocha-lavender.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#B4BEFE" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#B4BEFE" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#B4BEFE" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#B4BEFE" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#B4BEFE" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#B4BEFE" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#B4BEFE" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#B4BEFE" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#B4BEFE" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#B4BEFE" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#B4BEFE" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#B4BEFE" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#B4BEFE" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#B4BEFE" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#B4BEFE" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#B4BEFE" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#B4BEFE" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#B4BEFE" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#181825" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-mocha-maroon/catppuccin-mocha-maroon.svg
+++ b/themes/catppuccin-mocha-maroon/catppuccin-mocha-maroon.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#EBA0AC" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#EBA0AC" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#EBA0AC" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#EBA0AC" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#EBA0AC" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#EBA0AC" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#EBA0AC" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#EBA0AC" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#EBA0AC" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#EBA0AC" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#EBA0AC" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#EBA0AC" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#EBA0AC" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#EBA0AC" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#EBA0AC" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#EBA0AC" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#EBA0AC" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#EBA0AC" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#181825" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-mocha-mauve/catppuccin-mocha-mauve.svg
+++ b/themes/catppuccin-mocha-mauve/catppuccin-mocha-mauve.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#CBA6F7" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#CBA6F7" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#CBA6F7" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#CBA6F7" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#CBA6F7" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#CBA6F7" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#CBA6F7" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#CBA6F7" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#CBA6F7" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#CBA6F7" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#CBA6F7" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#CBA6F7" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#CBA6F7" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#CBA6F7" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#CBA6F7" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#CBA6F7" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#CBA6F7" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#CBA6F7" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#181825" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-mocha-peach/catppuccin-mocha-peach.svg
+++ b/themes/catppuccin-mocha-peach/catppuccin-mocha-peach.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#FAB387" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#FAB387" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#FAB387" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#FAB387" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#FAB387" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#FAB387" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#FAB387" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#FAB387" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#FAB387" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#FAB387" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#FAB387" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#FAB387" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#FAB387" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#FAB387" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#FAB387" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#FAB387" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#FAB387" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#FAB387" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#181825" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-mocha-pink/catppuccin-mocha-pink.svg
+++ b/themes/catppuccin-mocha-pink/catppuccin-mocha-pink.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#F5C2E7" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#F5C2E7" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#F5C2E7" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#F5C2E7" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#F5C2E7" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#F5C2E7" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#F5C2E7" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#F5C2E7" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#F5C2E7" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#F5C2E7" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#F5C2E7" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#F5C2E7" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#F5C2E7" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#F5C2E7" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#F5C2E7" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#F5C2E7" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#F5C2E7" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#F5C2E7" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#181825" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-mocha-red/catppuccin-mocha-red.svg
+++ b/themes/catppuccin-mocha-red/catppuccin-mocha-red.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#F38BA8" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#F38BA8" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#F38BA8" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#F38BA8" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#F38BA8" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#F38BA8" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#F38BA8" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#F38BA8" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#F38BA8" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#F38BA8" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#F38BA8" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#F38BA8" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#F38BA8" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#F38BA8" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#F38BA8" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#F38BA8" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#F38BA8" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#F38BA8" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#181825" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-mocha-rosewater/catppuccin-mocha-rosewater.svg
+++ b/themes/catppuccin-mocha-rosewater/catppuccin-mocha-rosewater.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#F5E0DC" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#F5E0DC" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#F5E0DC" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#F5E0DC" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#F5E0DC" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#F5E0DC" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#F5E0DC" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#F5E0DC" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#F5E0DC" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#F5E0DC" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#F5E0DC" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#F5E0DC" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#F5E0DC" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#F5E0DC" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#F5E0DC" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#F5E0DC" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#F5E0DC" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#F5E0DC" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#181825" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-mocha-sapphire/catppuccin-mocha-sapphire.svg
+++ b/themes/catppuccin-mocha-sapphire/catppuccin-mocha-sapphire.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#74C7EC" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#74C7EC" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#74C7EC" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#74C7EC" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#74C7EC" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#74C7EC" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#74C7EC" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#74C7EC" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#74C7EC" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#74C7EC" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#74C7EC" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#74C7EC" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#74C7EC" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#74C7EC" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#74C7EC" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#74C7EC" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#74C7EC" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#74C7EC" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#181825" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-mocha-sky/catppuccin-mocha-sky.svg
+++ b/themes/catppuccin-mocha-sky/catppuccin-mocha-sky.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#89DCEB" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#89DCEB" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#89DCEB" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#89DCEB" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#89DCEB" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#89DCEB" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#89DCEB" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#89DCEB" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#89DCEB" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#89DCEB" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#89DCEB" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#89DCEB" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#89DCEB" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#89DCEB" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#89DCEB" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#89DCEB" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#89DCEB" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#89DCEB" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#181825" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-mocha-teal/catppuccin-mocha-teal.svg
+++ b/themes/catppuccin-mocha-teal/catppuccin-mocha-teal.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#94E2D5" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#94E2D5" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#94E2D5" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#94E2D5" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#94E2D5" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#94E2D5" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#94E2D5" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#94E2D5" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#94E2D5" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#94E2D5" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#94E2D5" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#94E2D5" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#94E2D5" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#94E2D5" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#94E2D5" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#94E2D5" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#94E2D5" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#94E2D5" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#181825" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>

--- a/themes/catppuccin-mocha-yellow/catppuccin-mocha-yellow.svg
+++ b/themes/catppuccin-mocha-yellow/catppuccin-mocha-yellow.svg
@@ -194,20 +194,20 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#F9E2AF" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#F9E2AF" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#F9E2AF" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#F9E2AF" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#F9E2AF" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="opacity:0.2;fill:#F9E2AF" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#F9E2AF" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#F9E2AF" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#F9E2AF" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#F9E2AF" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#F9E2AF" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#F9E2AF" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#F9E2AF" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="opacity:0.2;fill:#F9E2AF" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="opacity:0.2;fill:#F9E2AF" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="opacity:0.2;fill:#F9E2AF" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="opacity:0.2;fill:#F9E2AF" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="opacity:0.2;fill:#F9E2AF" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#181825" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>


### PR DESCRIPTION
This replaces the toggled menu item color, with a 20% opacity color.

In Dolphin the result is this

Before:
![Screenshot_20241005_222501](https://github.com/user-attachments/assets/7c5cc054-3559-4759-9f96-01dd6ea1be5b)
After
![Screenshot_20241007_214118](https://github.com/user-attachments/assets/e9bbf2ad-d443-46e5-a0d5-e3e3b4b0fb35)

Currently this is not tested in any other application than Dolpin