### PR TITLE
build(whiskers): remove `capitalize_hex` & update to v2.5.0

### DIFF
--- a/templates/kvantum.tera
+++ b/templates/kvantum.tera
@@ -5,7 +5,7 @@ whiskers:
    - flavor
    - accent
   filename: 'themes/catppuccin-{{ flavor.identifier }}-{{ accent }}/catppuccin-{{ flavor.identifier }}-{{ accent }}.kvconfig'
-  capitalize_hex: true
+  hex_format: "{{R}}{{G}}{{B}}"
 ---
 [%General]
 author=elkrien based on Arc Dark style

--- a/templates/kvantum.tera
+++ b/templates/kvantum.tera
@@ -1,6 +1,6 @@
 ---
 whiskers:
-  version: "2.3.0"
+  version: "2.5.0"
   matrix:
    - flavor
    - accent

--- a/templates/svg.tera
+++ b/templates/svg.tera
@@ -1,6 +1,6 @@
 ---
 whiskers:
-  version: "2.3.0"
+  version: "2.5.0"
   matrix:
    - flavor
    - accent

--- a/templates/svg.tera
+++ b/templates/svg.tera
@@ -5,7 +5,7 @@ whiskers:
    - flavor
    - accent
   filename: 'themes/catppuccin-{{ flavor.identifier }}-{{ accent }}/catppuccin-{{ flavor.identifier }}-{{ accent }}.svg'
-  capitalize_hex: true
+  hex_format: "{{R}}{{G}}{{B}}"
 ---
 
 {%- set accent = flavor.colors[accent] -%}


### PR DESCRIPTION
This replaces the depricated `capitalize_hex` with  `hex_format`